### PR TITLE
Fix release manifest generation under TypeScript 6

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,12 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - run: npm --no-git-tag-version version ${{ github.event.release.tag_name }}
       - run: yarn run build
+      # @oclif/config v1 registers ts-node with hardcoded compiler options and
+      # never reads tsconfig.json; TypeScript 6 errors (TS5107) on the implicit
+      # moduleResolution=node10 unless silenced. Mirrors the default in bin/run.
       - run: oclif-dev manifest
+        env:
+          TS_NODE_COMPILER_OPTIONS: '{"ignoreDeprecations":"6.0"}'
       - run: ls -lah ./
       - run: npm publish --access public
 


### PR DESCRIPTION
Release 1.7.0 failed at the `oclif-dev manifest` step with `TS5107: Option 'moduleResolution=node10' is deprecated`.

**Root cause**: `oclif-dev manifest` loads command sources through `@oclif/config` v1's ts-node registration, which uses hardcoded compiler options and never reads `tsconfig.json`. TypeScript 6 turns the implicit `moduleResolution=node10` into a hard error. `bin/run` already defaults `TS_NODE_COMPILER_OPTIONS` for exactly this reason (f18a071), but the release workflow invokes `oclif-dev` directly and never got that default. This regressed in the PR #66 conflict resolution, where the `ignoreDeprecations` tsconfig line was dropped because PR CI (lint/test/build) doesn't exercise the manifest path — only releases do.

**Fix**: set the same `TS_NODE_COMPILER_OPTIONS` on the manifest step.

**Verified locally**: reproduced the exact TS5107 failure with `oclif-dev manifest`, confirmed the env var gets past TS compilation (remaining local error is only the sqlite3 binding, absent because of a `--ignore-scripts` install; the 1.7.0 run log shows CI's full `yarn` built it fine in 'Building fresh packages').

After merging, release 1.7.0 needs to be re-cut from main (the tag predates this fix and nothing was published to npm, so deleting and recreating the 1.7.0 release/tag is clean).