### PR TITLE
Fix empty package tarball: keep tsbuildinfo inside lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "target": "es2017",
     "composite": true,
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "useUnknownInCatchVariables": false


### PR DESCRIPTION
Second issue found in the failed 1.7.0 release (first was #68): the published tarball would have contained only 6 files (10.9 kB) — **no `lib/` at all** — because `prepack` runs `rm -rf lib && tsc -b`, but since the TS 6 upgrade the composite build info sits at the repo root and survives the deletion. `tsc -b` then reports up-to-date and emits nothing. Release 1.6.0 shipped 510 files by comparison.

Fix: set `tsBuildInfoFile` to `lib/tsconfig.tsbuildinfo` so the build info is deleted together with the output it describes.

Verified locally: `rm -rf lib && tsc -b` now re-emits every time (repeated twice), `yarn test` (51 passing) and lint green — `tsconfig.test.json` is unaffected since it disables incremental builds.

Note: the 1.7.0 publish itself failed on auth (npm E404 on PUT, i.e. masked 401 — the `NPM_TOKEN` secret has likely expired since the Sept 2025 release), which conveniently prevented this broken tarball from reaching the registry. Token rotation is handled separately.