### PR TITLE
Publish zindexer via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,9 +44,10 @@ jobs:
       - run: oclif-dev manifest
         env:
           TS_NODE_COMPILER_OPTIONS: '{"ignoreDeprecations":"6.0"}'
+      # zindexer publishes via npm trusted publishing (OIDC) — no token. The
+      # components package still needs the token until it exists on npmjs and
+      # can get its own trusted publisher configuration.
       - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm publish --access public --provenance
         working-directory: dist/components
         env:


### PR DESCRIPTION
The 2.0.0 release attempts fail with `EOTP` because npm uses the `NODE_AUTH_TOKEN` granular token, which is subject to the package's 2FA publishing policy. A trusted publisher is now configured on npmjs for `zindexer`, but npm only attempted the token since one was explicitly provided.

This drops the token from the zindexer publish step so npm performs the OIDC exchange (`id-token: write` is already set; setup-node's registry-url config stays). If the trusted publisher settings mismatch, the failure will now be explicit instead of a masked token fallback.

`@zencrepes/zindexer-components` keeps token auth for its first publish — a package that doesn't exist yet can't have a trusted publisher. Once it exists, it can be switched to OIDC too.