### PR TITLE
Make release publish steps idempotent

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,14 +44,30 @@ jobs:
       - run: oclif-dev manifest
         env:
           TS_NODE_COMPILER_OPTIONS: '{"ignoreDeprecations":"6.0"}'
+      # Publish steps skip versions already on the registry, so the workflow
+      # can be re-run after a partial failure without "cannot publish over".
       # zindexer publishes via npm trusted publishing (OIDC) — no token. The
       # components package still needs the token until it exists on npmjs and
       # can get its own trusted publisher configuration.
-      - run: npm publish --access public --provenance
-      - run: npm publish --access public --provenance
+      - name: Publish zindexer
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "zindexer@$VERSION" version >/dev/null 2>&1; then
+            echo "zindexer@$VERSION already published, skipping"
+          else
+            npm publish --access public --provenance
+          fi
+      - name: Publish components package
         working-directory: dist/components
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@zencrepes/zindexer-components@$VERSION" version >/dev/null 2>&1; then
+            echo "@zencrepes/zindexer-components@$VERSION already published, skipping"
+          else
+            npm publish --access public --provenance
+          fi
 
   npm_test:
     needs: [npm_publish]


### PR DESCRIPTION
zindexer@2.0.0 was successfully published via trusted publishing, but the components publish failed (EOTP on the token), and now any re-run of the release workflow dies at the zindexer step with "cannot publish over previously published versions" — so `npm_test` and `docker` never get to run.

This makes both publish steps check the registry first and skip versions that are already published, so the workflow can be safely re-run to completion after a partial failure.