### PR TITLE
Rename components package to @zencrepes/components

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,11 +31,11 @@ jobs:
           mkdir /tmp/components-smoke
           cd /tmp/components-smoke
           npm init -y
-          npm install /tmp/zencrepes-zindexer-components-*.tgz
+          npm install /tmp/zencrepes-components-*.tgz
           node -e '
-            const pkg = require("@zencrepes/zindexer-components/package.json");
+            const pkg = require("@zencrepes/components/package.json");
             const subpaths = Object.keys(pkg.exports).filter((p) => p !== "./package.json");
-            for (const p of subpaths) require("@zencrepes/zindexer-components/" + p.slice(2));
+            for (const p of subpaths) require("@zencrepes/components/" + p.slice(2));
             console.log("Loaded " + subpaths.length + " component subpaths");
           '
       # @oclif/config v1 registers ts-node with hardcoded compiler options and
@@ -63,8 +63,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if npm view "@zencrepes/zindexer-components@$VERSION" version >/dev/null 2>&1; then
-            echo "@zencrepes/zindexer-components@$VERSION already published, skipping"
+          if npm view "@zencrepes/components@$VERSION" version >/dev/null 2>&1; then
+            echo "@zencrepes/components@$VERSION already published, skipping"
           else
             npm publish --access public --provenance
           fi
@@ -88,8 +88,8 @@ jobs:
           mkdir /tmp/components-consumer
           cd /tmp/components-consumer
           npm init -y
-          npm install @zencrepes/zindexer-components@${{ github.event.release.tag_name }}
-          node -e 'require("@zencrepes/zindexer-components/config"); require("@zencrepes/zindexer-components/es-utils")'
+          npm install @zencrepes/components@${{ github.event.release.tag_name }}
+          node -e 'require("@zencrepes/components/config"); require("@zencrepes/components/es-utils")'
 
   docker:
     needs: [npm_test]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This readme only contains developer-focused details.
 
 # Shared components
 
-The directories under `src/components/` are shared with the other ZenCrepes services (zqueue, zapi). They are published to npmjs as a single package, `@zencrepes/zindexer-components`, with one subpath export per component (kebab-case, e.g. `src/components/esUtils` -> `@zencrepes/zindexer-components/es-utils`).
+The directories under `src/components/` are shared with the other ZenCrepes services (zqueue, zapi). They are published to npmjs as a single package, `@zencrepes/components`, with one subpath export per component (kebab-case, e.g. `src/components/esUtils` -> `@zencrepes/components/es-utils`).
 
 Within zindexer, components are used through plain relative imports — no release or publish step is needed during development. The package is assembled from the compiled output and published automatically alongside zindexer (same version) by the release workflow.
 
@@ -60,8 +60,8 @@ yarn build:components
 Consumers import individual components:
 
 ```ts
-import { zencrepesConfig } from '@zencrepes/zindexer-components/config';
-import { checkEsIndex, pushEsNodes } from '@zencrepes/zindexer-components/es-utils';
+import { zencrepesConfig } from '@zencrepes/components/config';
+import { checkEsIndex, pushEsNodes } from '@zencrepes/components/es-utils';
 ```
 
 Adding a component only requires creating a new directory with an `index.ts` under `src/components/`; it is picked up automatically at packaging time. Third-party packages used by components must be regular dependencies of zindexer (the packaging script derives the package's dependency list from them and fails otherwise).

--- a/scripts/build-components-package.js
+++ b/scripts/build-components-package.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Assembles the publishable @zencrepes/zindexer-components package from the
+// Assembles the publishable @zencrepes/components package from the
 // tsc output in lib/components. Run after `yarn build`; the package is
 // written to dist/components/ and published in lockstep with zindexer (same
 // version) by .github/workflows/publish-release.yml.
@@ -9,7 +9,7 @@ const path = require('path');
 const ROOT = path.join(__dirname, '..');
 const SRC = path.join(ROOT, 'lib', 'components');
 const OUT = path.join(ROOT, 'dist', 'components');
-const PACKAGE_NAME = '@zencrepes/zindexer-components';
+const PACKAGE_NAME = '@zencrepes/components';
 
 // Directory names are camelCase in src/components; published subpaths use
 // kebab-case, matching the names of the legacy @bit/zencrepes.zindexer.*


### PR DESCRIPTION
Every attempt to create `@zencrepes/zindexer-components` gets a bare 404 on PUT from the registry — including an interactive publish by the org owner with completed web-auth on npm 11.6 (client-side causes exhausted; suspected registry-side name restriction). Renaming to `@zencrepes/components` before first publish; no consumers exist yet so the rename is free.

Verified locally: assembled package, packed, installed in scratch project, all 20 subpaths require cleanly under the new name.